### PR TITLE
Use `lodash.shuffle` instead of `lodash` package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-meter-usage-reporter ChangeLog
 
+## 4.0.1 - TBD
+
+### Fixed
+- Use `lodash.shuffle` instead of `lodash` package to reduce potential
+  vulnerability surface.
+
 ## 4.0.0 - 2021-09-02
 - **BREAKING**: Meter usage no longer uses named clients and now depends
   on `bedrock-app-identity` for identity information for services.

--- a/lib/meters.js
+++ b/lib/meters.js
@@ -11,7 +11,7 @@ import {getServiceIdentities} from 'bedrock-app-identity';
 import {Ed25519Signature2020} from '@digitalbazaar/ed25519-signature-2020';
 import {logger} from './logger.js';
 import {OperationUsageCache} from './OperationUsageCache.js';
-import {shuffle} from 'lodash';
+import shuffle from 'lodash.shuffle';
 import {ZcapClient} from '@digitalbazaar/ezcap';
 
 const {config, util: {BedrockError}} = bedrock;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "abort-controller": "^3.0.0",
     "assert-plus": "^1.0.0",
     "delay": "^5.0.0",
-    "lodash": "^4.17.21"
+    "lodash.shuffle": "^4.2.0"
   },
   "peerDependencies": {
     "bedrock": "^4.0.0",


### PR DESCRIPTION
NPM audit is reporting this *disputed* CVE for lodash:  https://github.com/advisories/GHSA-8p5q-j9m2-g8wr

I think we want to use these minimal packages whenever possible to avoid being impacted by these sorts of things as much as possible.